### PR TITLE
fix: correct syntax error in input path argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,6 @@ runs:
       shell: bash
       run: |
         python ${{ github.action_path }}/publish_artifacts.py \
-          --path "${{ inputs.path}" \
+          --path "${{ inputs.path }}" \
           --destination "${{ inputs.destination }}" \
           --s3-bucket "${{ inputs.s3_bucket }}"


### PR DESCRIPTION
Add a missing closing brace in the ${{ inputs.path }} expression within the action.yml to fix the syntax error