### PR TITLE
Improve retry logic

### DIFF
--- a/publish_artifacts.py
+++ b/publish_artifacts.py
@@ -48,11 +48,20 @@ def upload_file(args):
         url = r.headers["location"]
         path = os.path.join(base, name)
         for x in (1, 2, 3, 0):
-            r = requests.put(
-                url,
-                data=open(path, "rb"),
-                headers={"Content-type": "application/octet-stream"},
-            )
+            try:
+                r = requests.put(
+                    url,
+                    data=open(path, "rb"),
+                    headers={"Content-type": "application/octet-stream"},
+                )
+            except Exception as e:
+                print(
+                    f"Unexpected error uploading {name}: {e}",
+                    flush=True,
+                    file=sys.stderr,
+                )
+                sleep(x)
+                continue
             if not r.ok:
                 if not x:
                     return (


### PR DESCRIPTION
We are starting to see errors from GCS where the socket fails:
```
|-> ERROR: HTTPSConnectionPool(host='storage.googleapis.com', port=443): Max retries exceeded with url: /quic-ci-artifacts/qualcomm-linux/qualcomm-linux/meta-qcom/21286077511-2/qcom-distro/qcom-armv7a/qcom-multimedia-image-qcom-armv7a.rootfs-20260123181428.ext4?Expires=1769193637&GoogleAccessId=gh-runner-fileserver%40fio-jobserv-ci.iam.gserviceaccount.com&Signature=2q9R2tZlw8tvuXu0sbxDPl6Qzh3svbXNwSzzEwCu0AqUHhRh0s78aW4eJ96xMAuin2WZ9ey8Fm2dYTkS9E0LhAOOwohW3I9anKDMmxMev7svKEfAaAqNtcvyA%2F0Stow4BR8HRzJ9DhLOp8lhGj0%2F5qA6Y%2FTl5Fk5WXSgjFQ94%2Fju5ezr%2FtdqHPk8BoTGlbZz6acg%2B3m%2BREwilSTcETm%2BXpnMm5w%2F9PN3X6PrzbgezKMkLyQWvpd5zrH1d12cguurVmgU%2B0qKZ1TxQLU%2BQ91FrB0Kvx1NJwiPkFvNc6uADpjFmx%2F1xRMgwy9y7Gxwa24Yed9J82SbHMurWO83U9wVWg%3D%3D (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:2427)')))
```

This change adds logic to catch connection errors and retry.