### PR TITLE
Dockerfile: switch from AWS CLI v1 to v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,21 @@
-FROM public.ecr.aws/docker/library/alpine:3.21
+FROM public.ecr.aws/ubuntu/ubuntu:24.04
 
 # Install dependencies
-RUN apk add --no-cache aws-cli
+RUN apt-get update && apt-get install -y curl unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install AWS CLI v2
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+    else \
+        echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
 
 # Copy entrypoint script into the container
 COPY publish_artifacts.sh /


### PR DESCRIPTION
- Installed AWS CLI v2 using official installer for x86_64 and aarch64

This ensures compatibility with newer S3 features and resolves ETag upload issues observed with AWS CLI v1.