### PR TITLE
publish_artifacts: reduce progress frequency to 30 seconds

### DIFF
--- a/publish_artifacts.sh
+++ b/publish_artifacts.sh
@@ -8,5 +8,5 @@ if ! aws sts get-caller-identity >/dev/null 2>&1; then
 fi
 
 # Step 2: Upload artifacts
-aws s3 cp "$INPUT_PATH" "s3://$INPUT_S3_BUCKET/$INPUT_DESTINATION" --recursive
+aws s3 cp "$INPUT_PATH" "s3://$INPUT_S3_BUCKET/$INPUT_DESTINATION" --recursive --progress-frequency 30
 


### PR DESCRIPTION
aws cp can be quite verbose when uploading files, which is not often desired during CI, so reduce the frequency to 30 seconds in order to still have a useful log in case of slow networks.