### PR TITLE
Add support to generate output URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,13 @@ inputs:
   s3_bucket:
     description: S3 bucket name
     required: true
+  fileserver_url:
+    description: URL used by clients to download content from the file server
+    required: false
+    default: "https://qli-prod-artifacts.qualcomm.com"
+outputs:
+  url:
+    description: "URL where objects are available at"
 
 runs:
   using: docker

--- a/publish_artifacts.sh
+++ b/publish_artifacts.sh
@@ -10,3 +10,6 @@ fi
 # Step 2: Upload artifacts
 aws s3 cp "$INPUT_PATH" "s3://$INPUT_S3_BUCKET/$INPUT_DESTINATION" --recursive --progress-frequency 30
 
+# Step 3: Publish fileserver URL containing the artifacts
+output_file="${GITHUB_OUTPUT}"
+echo "url=${INPUT_FILESERVER_URL}/${INPUT_S3_BUCKET}/${INPUT_DESTINATION}/" >> ${output_file}


### PR DESCRIPTION
Add fileserver_url as input and URL as output to allow clients to configure the address used for the HTTP S3 bucket interface.