### PR TITLE
TAG objects before uploading to S3 Bucket

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,16 @@ inputs:
   s3_bucket:
     description: S3 bucket name
     required: true
+  object_tag:
+    description: S3 Obeject tag for object retention, for example, "retention=7d" for artifacts kept for 7 days in the S3 bucket
+    required: true
+    default: 'retention=30d'
+  build_type:
+    description: Workflow type such as Pull Request or Push Build on a Branch
+    required: true
+  build_branch:
+    description: A build artifacts branch
+    required: true
   fileserver_url:
     description: URL used by clients to download content from the file server
     required: false

--- a/publish_artifacts.sh
+++ b/publish_artifacts.sh
@@ -8,7 +8,21 @@ if ! aws sts get-caller-identity >/dev/null 2>&1; then
 fi
 
 # Step 2: Upload artifacts
-aws s3 cp "$INPUT_PATH" "s3://$INPUT_S3_BUCKET/$INPUT_DESTINATION" --recursive --progress-frequency 30
+#aws s3 cp "$INPUT_PATH" "s3://$INPUT_S3_BUCKET/$INPUT_DESTINATION" --recursive --progress-frequency 30
+
+# Loop through all files recursively
+find "$INPUT_PATH" -type f | while read file; do
+    # Remove base path to preserve relative structure
+    relative_path="${file#$INPUT_PATH/}"
+
+    echo "Uploading: $relative_path"
+
+    aws s3api put-object \
+        --bucket "$INPUT_S3_BUCKET" \
+        --key "$INPUT_DESTINATION$relative_path" \
+        --body "$file" \
+        --tagging "$INPUT_OBJECT_TAG&$INPUT_BUILD_BRANCH&$INPUT_BUILD_TYPE"
+done
 
 # Step 3: Publish fileserver URL containing the artifacts
 output_file="${GITHUB_OUTPUT}"


### PR DESCRIPTION
IT has recently introduced a Tagging policy for S3, requiring each object to be tagged according to the retention policy, for example, "retention=7d" for artifacts kept for 7 days in the S3 bucket.

Additional tags like Build type and branch can help to isolate artifacts in the S3 Browser.