### PR TITLE
Replace put-object command with put-object-tagging

### DIFF
--- a/publish_artifacts.sh
+++ b/publish_artifacts.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # Step 1: Check AWS credentials
@@ -8,20 +8,47 @@ if ! aws sts get-caller-identity >/dev/null 2>&1; then
 fi
 
 # Step 2: Upload artifacts
-#aws s3 cp "$INPUT_PATH" "s3://$INPUT_S3_BUCKET/$INPUT_DESTINATION" --recursive --progress-frequency 30
+aws s3 cp "$INPUT_PATH" "s3://$INPUT_S3_BUCKET/$INPUT_DESTINATION" --recursive --progress-frequency 30
+
+# Step 3: Tag already upload artifacts
+#Validate TAGs
+
+for tag in "$INPUT_OBJECT_TAG" "$INPUT_BUILD_BRANCH" "$INPUT_BUILD_TYPE"; do
+  if [[ "$tag" != *=* ]]; then
+    echo "Invalid tag format: $tag"
+    exit 1
+  fi
+done
+
+OBJ_TAG_KEY="${INPUT_OBJECT_TAG%%=*}"
+OBJ_TAG_VALUE="${INPUT_OBJECT_TAG#*=}"
+
+BRANCH_TAG_KEY="${INPUT_BUILD_BRANCH%%=*}"
+BRANCH_TAG_VALUE="${INPUT_BUILD_BRANCH#*=}"
+
+BTYPE_TAG_KEY="${INPUT_BUILD_TYPE%%=*}"
+BTYPE_TAG_VALUE="${INPUT_BUILD_TYPE#*=}"
+
+TAGGING_JSON="$(cat <<EOF
+{
+  "TagSet": [
+    { "Key": "$OBJ_TAG_KEY",    "Value": "$OBJ_TAG_VALUE" },
+    { "Key": "$BRANCH_TAG_KEY", "Value": "$BRANCH_TAG_VALUE" },
+    { "Key": "$BTYPE_TAG_KEY",  "Value": "$BTYPE_TAG_VALUE" }
+  ]
+}
+EOF
+)"
 
 # Loop through all files recursively
 find "$INPUT_PATH" -type f | while read file; do
     # Remove base path to preserve relative structure
     relative_path="${file#$INPUT_PATH/}"
-
-    echo "Uploading: $relative_path"
-
-    aws s3api put-object \
+    echo "Tagging Object at: $relative_path"
+    aws s3api put-object-tagging \
         --bucket "$INPUT_S3_BUCKET" \
         --key "$INPUT_DESTINATION$relative_path" \
-        --body "$file" \
-        --tagging "$INPUT_OBJECT_TAG&$INPUT_BUILD_BRANCH&$INPUT_BUILD_TYPE"
+        --tagging "$TAGGING_JSON"
 done
 
 # Step 3: Publish fileserver URL containing the artifacts


### PR DESCRIPTION
AWS put-object has limitation on object size, the max upload size is 5GB, However there are artifacts over 5GB in size where it fails to upload via put-object command, to address this issue we will upload via CP command and then tag the object after we upload to S3 bucket.